### PR TITLE
Fix unmatched parenthesis in attribute_type_hint

### DIFF
--- a/src/all_filters.php
+++ b/src/all_filters.php
@@ -15,7 +15,7 @@ $replace = '$1 $4 = array( $5 );';
 $source = preg_replace($regexp, $replace, $source);
 
 // add class member type hints
-$regexp = '#\@(var|type)\s+([^\s]+)([^/]+)/\s+(var|public|protected|private)(\s+static)?)\s+(\$[^\s;=]+)#';
+$regexp = '#\@(var|type)\s+([^\s]+)([^/]+)/\s+(var|public|protected|private)(\s+static)?\s+(\$[^\s;=]+)#';
 $replace = '$3 */ $4 $5 $2 $6';
 $source = preg_replace($regexp, $replace, $source);
 

--- a/src/attribute_type_hints.php
+++ b/src/attribute_type_hints.php
@@ -25,7 +25,7 @@ $source = file_get_contents($argv[1]);
  *  private $var = 1;
  * ```
  */
-$regexp = '#\@(var|type)\s+([^\s]+)([^/]+)/\s+(var|public|protected|private)(\s+static)?)\s+(\$[^\s;=]+)#';
+$regexp = '#\@(var|type)\s+([^\s]+)([^/]+)/\s+(var|public|protected|private)(\s+static)?\s+(\$[^\s;=]+)#';
 $replace = '$3 */ $4 $5 $2 $6';
 $source = preg_replace($regexp, $replace, $source);
 


### PR DESCRIPTION
This commit fixes the following warning:

```
PHP Warning:  preg_replace(): Compilation failed: unmatched parentheses at offset 76 in /path/to/doxygen-php-filters/src/attribute_type_hints.php on line 30
```
