### PR TITLE
readme: Update doxygen host name and prefer HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # doxygen-php-filters
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/AbcAeffchen/doxygen-php-filters?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
-Filters to get [Doxygen](http://www.stack.nl/~dimitri/doxygen/) ([Doxygen on GitHub](https://github.com/doxygen/doxygen)) work better with PHP code.
+Filters to get [Doxygen](http://doxygen.nl/) ([Doxygen on GitHub](https://github.com/doxygen/doxygen)) work better with PHP code.
 
 ## How to use
 1. Choose your filter and download the `.php` file. If you want to use more than one filter, 
 you can combine them to one file or if you want to use all filters, you can use `all_filters.php`.
-2. Set the [`INPUT_FILTER`](http://www.stack.nl/~dimitri/doxygen/manual/config.html#cfg_input_filter) to `php filter_file_name.php`.  
+2. Set the [`INPUT_FILTER`](http://doxygen.nl/manual/config.html#cfg_input_filter) to `php filter_file_name.php`.  
 If PHP is not included in your PATH variable, you have to use `/path/to/php filter_file_name.php`
 instead.
 
 ## The Filters
 ### Short array syntax (`attribute_short_array_syntax.php`)
 This filter adds support for the short array syntax introduced with 
-[PHP 5.4](http://php.net/manual/de/migration54.new-features.php).
+[PHP 5.4](https://www.php.net/manual/en/migration54.new-features.php).
 If you have a multiline default value for a class member like this
 
     private $arr = [ 0 => [ ... ],
@@ -30,7 +30,7 @@ so doxygen can understand the array syntax right.
 ### Class member type hints (`attribute_type_hints.php`)
 There seems to be a [bug](https://bugzilla.gnome.org/show_bug.cgi?id=626105) that prevents
 doxygen from documenting class members with `@var`. The filter is a slight improvement from 
-[this Stackoverflow answer](http://stackoverflow.com/a/8472180/3440545) by Goran Rakic.  
+[this Stackoverflow answer](https://stackoverflow.com/a/8472180/3440545) by Goran Rakic.  
 **Notice**: The documentation string must not contain a slash (`/`).
 
 ### Support for `@return $this` (`method_return_this.php`)
@@ -49,7 +49,7 @@ and you have to use the string `if(!class_exists(` to get this filter work. The 
 that contains this string gets removed.
 
 ### Support/Workaround for traits (`traits.php`)
-Since PHP does not support inheritance from multiple classes, you maybe want to use [traits](http://php.net/manual/de/language.oop5.traits.php).
+Since PHP does not support inheritance from multiple classes, you maybe want to use [traits](https://www.php.net/manual/en/language.oop5.traits.php).
 But doxygen does not support this at all.
 
 This filter converts a trait into a class and transforms all usages of a trait into an inheritance.
@@ -70,7 +70,7 @@ becomes
 This is not valid PHP, but doxygen documents it as a multiple inheritance and you can see the methods
 of the traits in you class.
 
-**Notice**: This filter doesn't support [conflict resolution](http://php.net/manual/en/language.oop5.traits.php#language.oop5.traits.conflict).
+**Notice**: This filter doesn't support [conflict resolution](https://www.php.net/manual/en/language.oop5.traits.php#language.oop5.traits.conflict).
 So 
 
     class MyClass {
@@ -127,9 +127,9 @@ This also works if the documentation comment is already in the right place.
 Since this filter is very special to some users of Laravel, it is not included in the *all_filters* file.
 
 ## Credits
-Thanks to [Goran Rakic](http://stackoverflow.com/users/276152) for providing the class member hint filter in [this Stackoverflow answer](http://stackoverflow.com/a/8472180/3440545). 
+Thanks to [Goran Rakic](https://stackoverflow.com/users/276152) for providing the class member hint filter in [this Stackoverflow answer](https://stackoverflow.com/a/8472180/3440545). 
 This gave me the first push to write more filters.  
-Thanks to [Lorenz Meyer](http://stackoverflow.com/users/1951708) for improving the traits filter.  
-Thanks to [madankundu](http://stackoverflow.com/users/1627702) for testing the laravel_cron filter.
+Thanks to [Lorenz Meyer](https://stackoverflow.com/users/1951708) for improving the traits filter.  
+Thanks to [madankundu](https://stackoverflow.com/users/1627702) for testing the laravel_cron filter.
 ## License
 Licensed under the GPL v2.0 License.


### PR DESCRIPTION
* The doxygen site was moved, the previous url no longer works.
* Update urls to use HTTPS and/or their canonical domain to reduce redirects.
* Fix a `/de/` URL to use `/en/` instead for consistency with other php.net urls.