### PR TITLE
1 Add precision that it's a trait. 2 Allow several "use" statements. 

### DIFF
--- a/src/all_filters.php
+++ b/src/all_filters.php
@@ -57,20 +57,24 @@ if($openingBracePos !== false && $closingBracePos !== false)
     $source = $head . substr($tail,$openingBracePos+1,
                              $closingBracePos-$openingBracePos-1);
 
-// make traits to classes
-$regexp = '#trait([\s]+[\S]+[\s]*){#';
-$replace = 'class$1{';
+// make traits to classes and add "trait MyTraitName." in the comment so that the doc mentions somewhere that it is a trait
+// (Feel free to enhance if there's a better place to put this information, like this it will appear in the "detailed description" section)
+$regexp = '#(?:/\*\*((?:\*(?!/)|[^*])*?)\s*\*/\s*)?trait(\s+\S+\s*){#';
+$replace = "/**\n * trait $2.\n$1\n */\nclass$2{";
 $source = preg_replace($regexp, $replace, $source);
 
-// use traits by extending them (classes that not extending a class)
-$regexp = '#class([\s]+[\S]+[\s]*){[\s]+use([^;]+);#';
-$replace = 'class$1 extends $2 {';
-$source = preg_replace($regexp, $replace, $source);
-
-// use traits by extending them (classes that already extending a class)
-$regexp = '#class([\s]+[\S]+[\s]+extends[\s]+[\S]+[\s]*){[\s]+use([^;]+);#';
-$replace = 'class$1, $2 {';
-$source = preg_replace($regexp, $replace, $source);
+// use traits by extending the class using them
+// enhancement: now allows:
+// - to have more than one "use" statement in the class using the trait
+// - to have comments between the class opening brace { and the "use" statement, or between "use" statements
+$regexp = '#class(\s+\S+\s*)(extends[\s]+[\S]+[\s]*)?{((?:\s*(?:(?:\s*/[^\n]*\n)|(?:\s*/\*(?:(?:\*(?!/)|[^*])*?)\*/))*\s*use[^;]+;)+)#';
+function cbk($match){
+	$uses = preg_replace('#(?:(?:\s*//[^\n]*\n\s*)|(?:\s*/\*(?:(?:\*(?!/)|[^*])*?)\*/\s*))#', '', $match[3]);//remove comments
+	$uses = implode(', ', array_map('trim', explode(',', str_replace(['use',';'],['', ','], $uses))));
+	$extends = ($match[2]?'':'extends ').trim(implode(',', [$match[2], $uses]), ', ');
+	return "class{$match[1]}$extends {\n";
+}
+$source = preg_replace_callback($regexp, 'cbk', $source);
 
 // Output
 echo $source;

--- a/src/traits.php
+++ b/src/traits.php
@@ -9,20 +9,24 @@
 // Get the input
 $source = file_get_contents($argv[1]);
 
-// make traits to classes
-$regexp = '#trait([\s]+[\S]+[\s]*){#';
-$replace = 'class$1{';
+// make traits to classes and add "trait MyTraitName." in the comment so that the doc mentions somewhere that it is a trait
+// (Feel free to enhance if there's a better place to put this information, like this it will appear in the "detailed description" section)
+$regexp = '#(?:/\*\*((?:\*(?!/)|[^*])*?)\s*\*/\s*)?trait(\s+\S+\s*){#';
+$replace = "/**\n * trait $2.\n$1\n */\nclass$2{";
 $source = preg_replace($regexp, $replace, $source);
 
-// use traits by extending them (classes that not extending a class)
-$regexp = '#class([\s]+[\S]+[\s]*)(implements[\s]+[\S]+[\s]*)?{[\s]+use([^;]+);#';
-$replace = 'class$1 extends $3 $2 {';
-$source = preg_replace($regexp, $replace, $source);
-
-// use traits by extending them (classes that already extending a class)
-$regexp = '#class([\s]+[\S]+[\s]+extends[\s]+[\S]+[\s]*)(implements[\s]+[\S]+[\s]*)?{[\s]+use([^;]+);#';
-$replace = 'class$1, $3 $2{';
-$source = preg_replace($regexp, $replace, $source);
+// use traits by extending the class using them
+// enhancement: now allows:
+// - to have more than one "use" statement in the class using the trait
+// - to have comments between the class opening brace { and the "use" statement, or between "use" statements
+$regexp = '#class(\s+\S+\s*)(extends[\s]+[\S]+[\s]*)?{((?:\s*(?:(?:\s*/[^\n]*\n)|(?:\s*/\*(?:(?:\*(?!/)|[^*])*?)\*/))*\s*use[^;]+;)+)#';
+function cbk($match){
+	$uses = preg_replace('#(?:(?:\s*//[^\n]*\n\s*)|(?:\s*/\*(?:(?:\*(?!/)|[^*])*?)\*/\s*))#', '', $match[3]);//remove comments
+	$uses = implode(', ', array_map('trim', explode(',', str_replace(['use',';'],['', ','], $uses))));
+	$extends = ($match[2]?'':'extends ').trim(implode(',', [$match[2], $uses]), ', ');
+	return "class{$match[1]}$extends {\n";
+}
+$source = preg_replace_callback($regexp, 'cbk', $source);
 
 // Output
 echo $source;


### PR DESCRIPTION
Adds a "Trait MyTraitName." line in the "detailed section" of the doc, to make clear it's a trait and no class.

Allows to have several "use" statements in the including class, as well as comments before and/or between the "use" statements.